### PR TITLE
Fix for failing Schematic imports

### DIFF
--- a/SitemapPlugin.php
+++ b/SitemapPlugin.php
@@ -62,6 +62,12 @@ class SitemapPlugin extends BasePlugin
      */
     public function prepSettings($input)
     {
+        // early exit if $input is already a complete settings array
+        // like in a Schematic import
+        if (!array_key_exists('enabled', $input) && isset($input['sections']) && is_array($input['sections'])) {
+            return $input;
+        }
+        
         // We’re rewriting every time
         $settings = $this->defineSettings();
 


### PR DESCRIPTION
Schematic is calling `prepSettings` with an array which is already a complete settings array, so the prepping is skipped in this case.