### PR TITLE
Removed default 100 record limit

### DIFF
--- a/services/SitemapService.php
+++ b/services/SitemapService.php
@@ -147,6 +147,7 @@ class SitemapService extends BaseApplicationComponent
     {
         $criteria = craft()->elements->getCriteria(ElementType::Entry);
         $criteria->section = $section;
+        $criteria->limit = 0;
         if($includeiffield != null && !empty($includeiffield)) {
             $criteria->$includeiffield = 1;
         }


### PR DESCRIPTION
When a site has over 100 entries it only provides the first 100 records, providing an invalid sitemap. This change removes that limit.