### PR TITLE
Ensure attributes is defined

### DIFF
--- a/models/Sitemap_BaseModel.php
+++ b/models/Sitemap_BaseModel.php
@@ -11,6 +11,10 @@ abstract class Sitemap_BaseModel extends BaseModel
      */
     public function validate($attributes = null, $clearErrors = true)
     {
+        if ($attributes === null) {
+            $attributes = $this->getAttributes();
+        }
+
         $validate = parent::validate($attributes, $clearErrors);
 
         if (!$validate && craft()->config->get('devMode')) {


### PR DESCRIPTION
If we don't do this, devMode throws an exception that traces to the
$attributes not being defined here.