### PR TITLE
Fix saving settings when only 1 locale is present

### DIFF
--- a/SitemapPlugin.php
+++ b/SitemapPlugin.php
@@ -86,8 +86,8 @@ class SitemapPlugin extends BasePlugin
             }
         }
 
-        $settings['currentLocaleOnly'] = $input['currentLocaleOnly'] == '1';
-        $settings['addAlternateUrls'] = $input['addAlternateUrls'] == '1';
+        $settings['currentLocaleOnly'] = isset($input['currentLocaleOnly']) && $input['currentLocaleOnly'] == '1';
+        $settings['addAlternateUrls'] = isset($input['addAlternateUrls']) && $input['addAlternateUrls'] == '1';
 
         // Return the parsed settings ready for the database
         return $settings;


### PR DESCRIPTION
When there's only one locale, the fields aren't set in the post request which causes an error. So I've added a check to see if they exist