### PR TITLE
Add unique ID to plugin settings table

### DIFF
--- a/templates/_settings.html
+++ b/templates/_settings.html
@@ -38,7 +38,7 @@
   Choose which sections should be included in the sitemap.
 </p>
 
-<table class="data fullwidth">
+<table id="sitemap" class="data fullwidth">
   <thead>
     <th>{{ 'Enabled'|t }}</th>
     <th>{{ 'Section'|t }} </th>


### PR DESCRIPTION
@groe Hi there.

Thanks for taking over the original plugin and updating it. We had been using the original version (1.0.0.4) in a project, we recently needed to have the ability to exclude certain entries in the sitemap and your forked version provides it, so thanks for that!

My PR is a bit of unique case for our needs, but I'll explain. Basically, the include field in the settings menu that pulls in all lightswitch fields present in Craft is currently pushing the column quite wide, example below. This is because we have a web form that has a long label on one of the lightswitch fields, which is causing the ridiculous length of the `<select>` field column.

![image](https://user-images.githubusercontent.com/8067792/38781352-5b5d1018-40db-11e8-907f-737c276f6586.png)

Obviously, this isn't the plugins problem, but I was hoping to target the select field with CSS to set a `max-width` to prevent it. We already have another plugin that loads custom CSS/JS for the Craft CMS CP, so I can fix it, but I need a unique id/class to target, so it doesn't apply to every select field in the CP and it seems overkill to load an additional stylesheet in the plugin itself to fix something that's specific to our project.

Would you be happy to add an extra CSS id/class on the table, so it can be targeted in this way? I originally thought CSS class, but maybe an ID is better in this case?

Seems like a strange request, I know, but I just want to try and control that select field size, because of the long labels on a few of our lightswitch fields.

Thanks,

James


